### PR TITLE
cyres: get auth_key_pub from CSF data

### DIFF
--- a/arch/arm/cpu/armv8/fsl-layerscape/Makefile
+++ b/arch/arm/cpu/armv8/fsl-layerscape/Makefile
@@ -37,6 +37,7 @@ ifneq ($(CONFIG_ARCH_LS1012A),)
 obj-$(CONFIG_SYS_HAS_SERDES) += ls1012a_serdes.o
 ifdef CONFIG_SPL_BUILD
 obj-$(CONFIG_CYRES) += ls1012a_hw_ident.o
+obj-$(CONFIG_CYRES) += ls1012a_hab.o
 endif
 endif
 

--- a/arch/arm/cpu/armv8/fsl-layerscape/ls1012a_hab.c
+++ b/arch/arm/cpu/armv8/fsl-layerscape/ls1012a_hab.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier:	BSD-3-Clause
+ */
+#include <common.h>
+#include <fsl_sfp.h>
+#include <fsl_validate.h>
+#include <isbc_hdr_ta_2_x.h>
+#include <fsl_hab.h>
+
+#define CONFIG_DCFG_ADDR	CONFIG_SYS_FSL_GUTS_ADDR
+
+static const u8 barker_code[] = { 0x68, 0x39, 0x27, 0x81 };
+
+/* this function duplicates fsl_check_boot_mode_secure, but it was
+   simpler to copy it than refactor */
+static bool is_hab_enabled(void)
+{
+	uint32_t val;
+	struct ccsr_sfp_regs *sfp_regs = (void *)(CONFIG_SYS_SFP_ADDR);
+	struct ccsr_gur __iomem *gur = (void *)(CONFIG_DCFG_ADDR);
+
+	val = sfp_in32(&sfp_regs->ospr);
+	if (val & ITS_MASK)
+		return true;
+
+	/* For PBL based platforms check the SB_EN bit in RCWSR */
+	val = in_be32(&gur->rcwsr[RCW_SB_EN_REG_INDEX - 1]);
+	if (val & RCW_SB_EN_MASK)
+		return true;
+
+	return false;
+}
+
+/* this function duplicates get_csf_base_addr in fsl_validate.c */
+static int get_csf_base_addr(void **csf_addr)
+{
+	struct ccsr_gur __iomem *gur = (void *)(CONFIG_SYS_FSL_GUTS_ADDR);
+	u32 csf_hdr_addr = in_be32(&gur->scratchrw[0]);
+
+	if (memcmp((u8 *)(uintptr_t)csf_hdr_addr,
+		   barker_code, ISBC_BARKER_LEN)) {
+
+		printf("CSF barker code mismatch: 0x%x\n",
+		       *(u32 *)(uintptr_t)csf_hdr_addr);
+		return -1;
+	}
+
+	*csf_addr = (void *)(uintptr_t)csf_hdr_addr;
+	return 0;
+}
+
+int get_spl_auth_key_pub(u8 *key, size_t size, size_t *key_size)
+{
+	int ret;
+	const struct srk_table *srk_tbl;
+	u32 offset;
+	const u8 *key_ptr;
+	size_t key_len;
+	const struct isbc_hdr_ta_2_1 *csf_hdr;
+
+	if (!is_hab_enabled()) {
+		printf("can't get CSF - HAB disabled\n");
+		return -1;
+	}
+
+	ret = get_csf_base_addr((void **)&csf_hdr);
+	if (ret)
+		return ret;
+
+	if (csf_hdr->len_kr.srk_table_flag != 0) {
+		offset = csf_hdr->srk_table_offset +
+			((csf_hdr->len_kr.key_num_verify - 1) *
+			 sizeof(struct srk_table));
+
+		srk_tbl = (struct srk_table *)((u8 *)csf_hdr + offset);
+		key_ptr = srk_tbl->pkey;
+		key_len = srk_tbl->key_len;
+	} else {
+		key_ptr = (u8 *)csf_hdr + csf_hdr->pkey;
+		key_len = csf_hdr->key_len;
+	}
+
+	if (size < key_len) {
+		return -EINVAL;
+	}
+
+	memcpy(key, key_ptr, key_len);
+	*key_size = key_len;
+
+	return 0;
+}

--- a/common/cyres.c
+++ b/common/cyres.c
@@ -17,11 +17,7 @@ static int uboot_ret_from_cyres(cyres_result res)
 	return (int)res;
 }
 
-int build_cyres_cert_chain(const char *next_image_name,
-			   const u8 *next_image_digest,
-			   size_t digest_size,
-			   const u8 *auth_key_pub,
-			   size_t auth_key_pub_size)
+int build_cyres_cert_chain(const struct build_cyres_cert_chain_args *args)
 {
 	cyres_result res;
 	struct cyres_cert_blob *cert_blob = NULL;
@@ -30,9 +26,7 @@ int build_cyres_cert_chain(const char *next_image_name,
 	struct cyres_key_pair device_key_pair;
 	struct cyres_key_pair next_image_key_pair;
 	struct cyres_root_cert_args root_args;
-	struct cyres_gen_alias_cert_args args;
-	uint8_t fake_spl_auth_key_pub[1] = { 0 }; /* XXX get the public key that
-						     was used to validate SPL */
+	struct cyres_gen_alias_cert_args alias_args;
 
 	res = read_and_hide_cyres_identity(&identity);
 	if (res != 0) {
@@ -54,8 +48,8 @@ int build_cyres_cert_chain(const char *next_image_name,
 	root_args.identity_size = sizeof(identity.data);
 	root_args.fwid = (const uint8_t *)U_BOOT_VERSION;
 	root_args.fwid_size = sizeof(U_BOOT_VERSION);
-	root_args.auth_key_pub = fake_spl_auth_key_pub;
-	root_args.auth_key_pub_size = sizeof(fake_spl_auth_key_pub);
+	root_args.auth_key_pub = args->spl_auth_key_pub;
+	root_args.auth_key_pub_size = args->spl_auth_key_pub_size;
 	root_args.device_cert_subject = "SPL";
 	root_args.root_path_len = CONFIG_CYRES_CERT_CHAIN_PATH_LENGTH;
 
@@ -66,29 +60,29 @@ int build_cyres_cert_chain(const char *next_image_name,
 		goto end;
 	}
 
-	memset(&args, 0, sizeof(args));
-	args.issuer_key_pair = &device_key_pair;
-	args.seed_data = &device_key_pair.priv;
-	args.seed_data_size = sizeof(device_key_pair.priv);
-	args.subject_digest = next_image_digest;
-	args.subject_digest_size = digest_size;
-	args.auth_key_pub = auth_key_pub;
-	args.auth_key_pub_size = auth_key_pub_size;
-	args.subject_name = next_image_name;
-	args.issuer_name = "SPL";
-	args.path_len = 2;
+	memset(&alias_args, 0, sizeof(alias_args));
+	alias_args.issuer_key_pair = &device_key_pair;
+	alias_args.seed_data = &device_key_pair.priv;
+	alias_args.seed_data_size = sizeof(device_key_pair.priv);
+	alias_args.subject_digest = args->next_image_digest;
+	alias_args.subject_digest_size = args->next_image_digest_size;
+	alias_args.auth_key_pub = args->next_image_auth_key_pub;
+	alias_args.auth_key_pub_size = args->next_image_auth_key_pub_size;
+	alias_args.subject_name = args->next_image_name;
+	alias_args.issuer_name = "SPL";
+	alias_args.path_len = 2;
 
-	res = cyres_gen_alias_cert(&args, &cert, &next_image_key_pair);
+	res = cyres_gen_alias_cert(&alias_args, &cert, &next_image_key_pair);
 	if (res) {
 		debug("Failed to generate cert for %s\n",
-		      next_image_name);
+		      args->next_image_name);
 		goto end;
 	}
 
 	res = cyres_insert_cert(cert_blob, cert);
 	if (res) {
 		debug("Failed to append cert (%s) to cert chain",
-		      next_image_name);
+		      args->next_image_name);
 		goto end;
 	}
 

--- a/include/cyres.h
+++ b/include/cyres.h
@@ -11,17 +11,30 @@ struct cyres_hw_identity {
 	u32 data[8];
 };
 
+struct build_cyres_cert_chain_args {
+	/* public key used to validate SPL for high assurance boot */
+	const u8 *spl_auth_key_pub;
+	size_t spl_auth_key_pub_size;
+
+	/* subject name to use for the next certificate in the cert chain */
+	const char *next_image_name;
+
+	/* digest (SHA256) of the next image in the cert chain */
+	const u8 *next_image_digest;
+	size_t next_image_digest_size;
+
+	/* public key used to validate the next image in the cert chain */
+	const u8 *next_image_auth_key_pub;
+	size_t next_image_auth_key_pub_size;
+};
+
 /*
  * Builds a Cyres certificate chain and places it at
  * CONFIG_CYRES_CERT_CHAIN_ADDR. Boot loader code should call this when
  * the next boot stage image has been loaded into memory and hashed.
  * next_image_name becomes the certificate subject name.
  */
-int build_cyres_cert_chain(const char *next_image_name,
-			   const u8 *next_image_digest,
-			   size_t digest_size,
-			   const u8 *auth_key_pub,
-			   size_t auth_key_pub_size);
+int build_cyres_cert_chain(const struct build_cyres_cert_chain_args *args);
 
 /*
  * Implemented by the platform to read a stable device-unique identity,

--- a/include/fsl_hab.h
+++ b/include/fsl_hab.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * SPDX-License-Identifier:   BSD-3-Clause
+ *
+ * Utilities related to HAB
+ */
+#ifndef __FSL_HAB_H__
+#define __FSL_HAB_H__
+
+/*
+ * Get the public key used to validate SPL
+ *
+ * key - buffer allocated by caller into which the key is copied
+ * size - size of the buffer
+ * key_size - on success, receives actual number of bytes copied to buffer
+ */
+int get_spl_auth_key_pub(u8 *key, size_t size, size_t *key_size);
+
+#endif /* __FSL_HAB_H__ */

--- a/include/isbc_hdr_ta_2_x.h
+++ b/include/isbc_hdr_ta_2_x.h
@@ -1,0 +1,132 @@
+/* Copyright (c) 2015 Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Freescale Semiconductor nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY Freescale Semiconductor ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Freescale Semiconductor BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _ISBC_HDR_TA_2_X_H_
+#define _ISBC_HDR_TA_2_X_H_
+
+/**********************************************************
+ * HEADER Structures
+ **********************************************************/
+#define MAX_SG_TA_2_X		8
+#define MAX_SRK_TA_2_X		4
+#define ISBC_BARKER_LEN		4
+
+struct isbc_hdr_ta_2_0 {
+	uint8_t barker[ISBC_BARKER_LEN];	/* 0x00 Barker code */
+	union {
+		uint32_t srk_table_offset;	/* SRK Table Offset */
+		uint32_t pkey;			/* Public Key */
+	};				/* 0x04 */
+
+	union {
+		uint32_t key_len;
+		struct {
+			uint32_t srk_table_flag:8;
+			uint32_t key_num_verify:8;
+			uint32_t num_keys:16;
+		}len_kr;
+	};				/* 0x08 */
+
+	uint32_t psign;			/* 0x0c signature offset */
+	uint32_t sign_len;		/* 0x10 length of signature */
+
+	uint32_t sg_table_addr;		/* 0x14 ptr to SG table */
+	uint32_t sg_entries;		/* 0x18 no. of entries in SG */
+	uint32_t entry_point;		/* 0x1c ESBC entry point */
+
+	union {
+		uint32_t sg_flag;
+		struct {
+			uint32_t mp_flag:16;	/* Mfg Protection flag */
+			uint32_t sg_flag:16;	/* Scatter gather flag */
+		}mp_n_sg_flag;
+	};				/* 0x20 */
+
+	union {
+		uint32_t uid_flag;	/* Flag to indicate uid */
+		struct {
+			uint32_t sfp_wp:8;
+			uint32_t sec_image_flag:8;
+			uint32_t uid_flag:16;
+		}uid_n_wp;
+	};				/* 0x24 */
+	uint32_t fsl_uid_0;		/* 0x28 Freescale unique id */
+	uint32_t oem_uid_0;		/* 0x2c OEM unique id */
+
+	uint32_t hkarea;		/* 0x30 HK Area */
+	uint32_t hksize;		/* 0x34 HK Area */
+	uint32_t res2[2];		/* 0x38 - 0x3c */
+};
+
+struct isbc_hdr_ta_2_1 {
+	uint8_t barker[ISBC_BARKER_LEN];	/* 0x00 Barker code */
+	union {
+		uint32_t srk_table_offset;	/* SRK Table Offset */
+		uint32_t pkey;			/* Public Key */
+	};				/* 0x04 */
+
+	union {
+		uint32_t key_len;
+		struct {
+			uint32_t srk_table_flag:8;
+			uint32_t key_num_verify:8;
+			uint32_t num_keys:16;
+		}len_kr;
+	};				/* 0x08 */
+
+	uint32_t psign;			/* 0x0c signature offset */
+	uint32_t sign_len;		/* 0x10 length of signature */
+
+	uint32_t sg_table_addr;		/* 0x14 ptr to SG table */
+	uint32_t sg_entries;		/* 0x18 no. of entries in SG */
+	uint32_t entry_point;		/* 0x1c ESBC entry point */
+
+	union {
+		uint32_t sg_flag;
+		struct {
+			uint32_t mp_flag:16;	/* Mfg Protection flag */
+			uint32_t sg_flag:16;	/* Scatter gather flag */
+		}mp_n_sg_flag;
+	};				/* 0x20 MP Flag */
+
+	union {
+		uint32_t uid_flag;	/* Flag to indicate uid */
+		struct {
+			uint32_t sfp_wp:8;
+			uint32_t sec_image_flag:8;
+			uint32_t uid_flag:16;
+		}uid_n_wp;
+	};				/* 0x24 */
+	uint32_t fsl_uid_0;		/* 0x28 Freescale unique id */
+	uint32_t oem_uid_0;		/* 0x2c OEM unique id */
+
+	uint32_t res2[2];		/* 0x30 - 0x34 */
+	uint32_t fsl_uid_1;		/* 0x38 Freescale unique id */
+	uint32_t oem_uid_1;		/* 0x3c OEM unique id */
+};
+
+#endif


### PR DESCRIPTION
Get the key used to validate SPL from the CSF header. This is the
public part of the Super Root Key (SRK), whose hash is burned into fuses
and is used in High Assurance Boot.