### PR TITLE
imx8mm: change default UART

### DIFF
--- a/include/configs/imx8mm_evk.h
+++ b/include/configs/imx8mm_evk.h
@@ -269,7 +269,7 @@
 #endif
 
 #define CONFIG_MXC_UART
-#define CONFIG_MXC_UART_BASE		UART4_BASE_ADDR
+#define CONFIG_MXC_UART_BASE		UART2_BASE_ADDR
 
 /* Monitor Command Prompt */
 #undef CONFIG_SYS_PROMPT


### PR DESCRIPTION
- Change default UART to UART2 for iMX8M Mini.  UART4 is reserved for M4 core in Arm Trusted Firmware.